### PR TITLE
Fix lower-case "javascript" tag

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -278,7 +278,7 @@
     "desc": "Find the array method you need without digging through the docs",
     "url": "https://arrayexplorer.netlify.com/",
     "tags": [
-      "javascript"
+      "JavaScript"
     ],
     "maintainers": [
       "sdras"


### PR DESCRIPTION
This made eleventy builds choke.