### PR TITLE
chore: add brotli.pro

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -726,5 +726,16 @@
     ],
     "maintainers": [],
     "addedAt": "2019-12-29"
+  },
+  {
+    "name": "Brotli.Pro",
+    "url": "https://brotli.pro/?ref=tiny-helpers.dev",
+    "desc": "Check if your website supports Brotli compression",
+    "tags": [
+      "Compression",
+      "Performance"
+    ],
+    "maintainers": [],
+    "addedAt": "2019-12-29"
   }
 ]

--- a/helpers.json
+++ b/helpers.json
@@ -729,10 +729,9 @@
   },
   {
     "name": "Brotli.Pro",
-    "url": "https://brotli.pro/?ref=tiny-helpers.dev",
+    "url": "https://brotli.pro/",
     "desc": "Check if your website supports Brotli compression",
     "tags": [
-      "Compression",
       "Performance"
     ],
     "maintainers": [],

--- a/helpers.json
+++ b/helpers.json
@@ -736,6 +736,6 @@
       "Performance"
     ],
     "maintainers": [],
-    "addedAt": "2019-12-29"
+    "addedAt": "2020-01-18"
   }
 ]


### PR DESCRIPTION
Adds https://www.brotli.pro/ - a website to check whether a given webpage supports Brotli encryption or not ☺️ 