### PR TITLE
new helper added: Browser Default Styles

### DIFF
--- a/helpers.json
+++ b/helpers.json
@@ -1,9 +1,22 @@
 [
   {
+    "name": "\\Browser Default Styles",
+    "desc": "Search against any element for standardized and default styles from all major rendering engines (WebKit, Blink, Gecko, Trident).",
+    "url": "https://browserdefaultstyles.com/",
+    "tags": [
+      "Images"
+    ],
+    "maintainers": [],
+    "addedAt": "2020-01-18"
+  },
+  {
     "name": "Accessible Brand Colors",
     "desc": "Evaluate the ADA compliance of your brand's color palette.",
     "url": "https://abc.useallfive.com/",
-    "tags": ["Accessibility", "Color"],
+    "tags": [
+      "Accessibility",
+      "Color"
+    ],
     "maintainers": [
       "scottqmn",
       "huckpilot",
@@ -62,6 +75,19 @@
     "addedAt": "2020-01-14"
   },
   {
+    "name": "Browser Default Styles",
+    "desc": "Search against any element for standardized and default styles from all major rendering engines (WebKit, Blink, Gecko, Trident).",
+    "url": "https://browserdefaultstyles.com/",
+    "tags": [
+      "HTML",
+      "Misc"
+    ],
+    "maintainers": [
+      "UncaughtTypeError"
+    ],
+    "addedAt": "2020-01-18"
+  },
+  {
     "name": "carbon",
     "desc": "Create and share beautiful images of your source code",
     "url": "https://carbon.now.sh/",
@@ -106,20 +132,6 @@
       "crgeary"
     ],
     "addedAt": "2020-01-14"
-  },
-  {
-    "name": "Eightshapes Contrast Grid",
-    "desc": "Test many foreground and background color combos for compliance with WCAG 2.0 minimum contrast.",
-    "url": "https://contrast-grid.eightshapes.com/",
-    "tags": [
-      "Accessibility",
-      "Color"
-    ],
-    "maintainers": [
-      "kevinmpowell",
-      "nathanacurtis"
-    ],
-    "addedAt": "2020-01-13"
   },
   {
     "name": "cryptii.com",
@@ -207,6 +219,20 @@
       "LeaVerou"
     ],
     "addedAt": "2020-01-15"
+  },
+  {
+    "name": "Eightshapes Contrast Grid",
+    "desc": "Test many foreground and background color combos for compliance with WCAG 2.0 minimum contrast.",
+    "url": "https://contrast-grid.eightshapes.com/",
+    "tags": [
+      "Accessibility",
+      "Color"
+    ],
+    "maintainers": [
+      "kevinmpowell",
+      "nathanacurtis"
+    ],
+    "addedAt": "2020-01-13"
   },
   {
     "name": "Explain Shell",

--- a/helpers.json
+++ b/helpers.json
@@ -1,15 +1,5 @@
 [
   {
-    "name": "\\Browser Default Styles",
-    "desc": "Search against any element for standardized and default styles from all major rendering engines (WebKit, Blink, Gecko, Trident).",
-    "url": "https://browserdefaultstyles.com/",
-    "tags": [
-      "Images"
-    ],
-    "maintainers": [],
-    "addedAt": "2020-01-18"
-  },
-  {
     "name": "Accessible Brand Colors",
     "desc": "Evaluate the ADA compliance of your brand's color palette.",
     "url": "https://abc.useallfive.com/",


### PR DESCRIPTION
Added new helper: Browser Default Styles

A nifty little tool one can use to search against any element for standardized and default styles from all major rendering engines (WebKit, Blink, Gecko, Trident).
