### PR TITLE
[meta] Parallelize screenshots (and don't grab them if they exist)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "inquirer": "^7.0.1",
     "jimp": "^0.9.3",
     "now": "^16.7.3",
+    "p-limit": "^2.2.2",
     "postcss": "^7.0.26",
     "postcss-clean": "^1.1.0",
     "postcss-import": "^12.0.1",

--- a/scripts/create-screenshots.js
+++ b/scripts/create-screenshots.js
@@ -1,57 +1,54 @@
+const pLimit = require('p-limit');
 const puppeteer = require('puppeteer');
-const { mkdir, stat } = require('fs').promises;
+const { stat } = require('fs').promises;
 const { join } = require('path');
 const Jimp = require('jimp');
 const { getHelpers } = require('../lib/helpers');
 const { toSlug } = require('../lib/slug');
 
-// TODO parallize all this stuff to speed it up
-(async () => {
-  const helpers = await getHelpers();
+async function exists(path) {
   try {
-    const screenshotDir = join(__dirname, '..', 'static', 'screenshots');
-    try {
-      await stat(screenshotDir);
-    } catch (e) {
-      if (e.code === 'ENOENT') {
-        console.log('Creating screenshot directory...');
-        await mkdir(screenshotDir);
-      } else {
-        throw e;
-      }
-    }
-    const browser = await puppeteer.launch();
+    await stat(path);
+    return true;
+  } catch (err) {
+    if (err.code === 'ENOENT') return false;
+    throw err;
+  }
+}
+
+async function makeScreenshots(browser, helper, screenshotDir) {
+  const doubleSize = join(screenshotDir, `${toSlug(helper.name)}@2.jpg`);
+  const singleSize = join(screenshotDir, `${toSlug(helper.name)}@1.jpg`);
+  let sigil = '✅';
+  if (!(await exists(doubleSize))) {
     const page = await browser.newPage();
     page.setViewport({
       width: 1000,
       height: 600
     });
-
-    const imagePaths = [];
-    for await (const helper of helpers) {
-      console.log(`📸 ${helper.name} at ${helper.url}...`);
-      await page.goto(helper.url);
-      const path = `static/screenshots/${toSlug(helper.name)}@2.jpg`;
-      await page.screenshot({
-        path
-      });
-
-      imagePaths.push(path);
-      console.log(`✅ ${helper.name}`);
-    }
-    await browser.close();
-    console.log('Screenshots taken...');
-
-    console.log('Resizing images...');
-    for await (const path of imagePaths) {
-      console.log(`Resizing ${path}...`);
-      const image = await Jimp.read(path);
-      await image
-        .quality(75)
-        .resize(500, Jimp.AUTO)
-        .write(`${path.split('@')[0]}@1.jpg`);
-    }
-  } catch (error) {
-    console.error(error);
+    await page.goto(helper.url);
+    await page.screenshot({ path: doubleSize });
+    await page.close();
+    sigil = '📸';
   }
+  if (!(await exists(singleSize))) {
+    await (await Jimp.read(doubleSize))
+      .quality(75)
+      .resize(500, Jimp.AUTO)
+      .write(singleSize);
+  }
+  console.log(`${sigil} ${helper.name} at ${helper.url}`);
+}
+
+(async () => {
+  const screenshotDir = join(__dirname, '..', 'static', 'screenshots');
+  const helpers = await getHelpers();
+  console.log('Taking screenshots...');
+  const browser = await puppeteer.launch();
+  const limit = pLimit(8);
+  const screenshotPromises = helpers.map((helper) =>
+    limit(() => makeScreenshots(browser, helper, screenshotDir))
+  );
+  await Promise.all(screenshotPromises);
+  await browser.close();
 })();


### PR DESCRIPTION
* Parallelize grabbing screenshots (with a parallelism limit though)
* Don't do anything if a screenshot already exists for a given site
  * In the future, screenshots could maybe be stored in the repo to avoid having to fetch them on every build?