### PR TITLE
Added Input Types helper

### DIFF
--- a/helpers/input-type-sandbox.json
+++ b/helpers/input-type-sandbox.json
@@ -1,0 +1,14 @@
+{
+  "name": "Input Type Sandbox",
+  "desc": "Test form input types, onscreen keyboards and more",
+  "url": "https://inputtypes.com",
+  "tags": [
+    "HTML",
+    "Misc",
+    "Regular Expressions"
+  ],
+  "maintainers": [
+    "aladage"
+  ],
+  "addedAt": "2020-01-21"
+}

--- a/helpers/input-type-sandbox.json
+++ b/helpers/input-type-sandbox.json
@@ -4,8 +4,7 @@
   "url": "https://inputtypes.com",
   "tags": [
     "HTML",
-    "Misc",
-    "Regular Expressions"
+    "Forms"
   ],
   "maintainers": [
     "aladage"


### PR DESCRIPTION
This PR adds Input Types Sandbox (inputtypes.com) as a Tiny Helper.

Please note: I followed the advice of not adding a new Tag. However, I do think a "forms" tag would be appropriate for this helper, and would grow to include many others over time. Feel free to add if you feel this is a good idea.

Thanks, and I love the idea of this site!