### PR TITLE
Adds SSLMate's CAA Record Helper

### DIFF
--- a/helpers/caa-record-helper.json
+++ b/helpers/caa-record-helper.json
@@ -1,0 +1,12 @@
+{
+  "name": "CAA Record Helper",
+  "desc": "Generates CAA policies for domains",
+  "url": "https://sslmate.com/caa/",
+  "tags": [
+    "Security"
+  ],
+  "maintainers": [
+    "AGWA"
+  ],
+  "addedAt": "2020-01-22"
+}


### PR DESCRIPTION
https://sslmate.com/caa/ is super useful. Goes hand in hand with the other SSL related tools recommended on the security page.

https://sslmate.com/caa/about