### PR TITLE
[meta] Old PR rollup

### DIFF
--- a/helpers/alchemize.json
+++ b/helpers/alchemize.json
@@ -1,0 +1,15 @@
+{
+  "name": "Alchemize",
+  "desc": "Minify, pretty print & view code or JSON snippets.",
+  "url": "https://alchemizeapp.com/",
+  "tags": [
+    "APIs",
+    "Code",
+    "HTML",
+    "JavaScript"
+  ],
+  "maintainers": [
+    "ashkyd"
+  ],
+  "addedAt": "2020-01-16"
+}

--- a/helpers/ratio-buddy.json
+++ b/helpers/ratio-buddy.json
@@ -1,0 +1,14 @@
+{
+  "name": "Ratio Buddy",
+  "desc": "Calculate CSS aspect ratio's",
+  "url": "https://ratiobuddy.com",
+  "tags": [
+    "CSS",
+    "Code"
+  ],
+  "maintainers": [
+    "Tristam3000",
+    "benjackson84"
+  ],
+  "addedAt": "2020-01-16"
+}

--- a/helpers/svg-symbol-viewer.json
+++ b/helpers/svg-symbol-viewer.json
@@ -1,0 +1,12 @@
+{
+  "name": "SVG Symbol Viewer",
+  "desc": "An online, no-upload drag-and-drop SVG file symbol extractor and viewer",
+  "url": "https://svgsymbolviewer.io",
+  "tags": [
+    "SVG"
+  ],
+  "maintainers": [
+    "@jaydenseric"
+  ],
+  "addedAt": "2020-01-13"
+}


### PR DESCRIPTION
This splits the `helpers.json` changes from #4, #63, and #64 into conflict-free `helpers/*` files.

Closes #4
Closes #63 
Closes #64 