### PR TITLE
update flexbox-playground url

### DIFF
--- a/helpers/flexbox-playground.json
+++ b/helpers/flexbox-playground.json
@@ -1,7 +1,7 @@
 {
   "name": "Flexbox Playground",
   "desc": "Visually explore building out any flexbox layout and view generated HTML/CSS markup",
-  "url": "https://flexbox.mcbride.tech",
+  "url": "https://flexbox.tech",
   "tags": [
     "CSS"
   ],


### PR DESCRIPTION
Flexbox playground URL is moving to a dedicated domain.