### PR TITLE
feature: add CSS specificity selector app

### DIFF
--- a/helpers/css-specificity-calculator.json
+++ b/helpers/css-specificity-calculator.json
@@ -1,0 +1,12 @@
+{
+  "name": "CSS specificity calculator",
+  "desc": "Calculate the specificity of a given CSS selector",
+  "url": "https://polypane.app/css-specificity-calculator/",
+  "tags": [
+    "CSS"
+  ],
+  "maintainers": [
+    "kilian"
+  ],
+  "addedAt": "2020-02-24"
+}


### PR DESCRIPTION
- [x] you only add one (!) new helper per pull request.
- [x] you have checked if an open PR already exists.
- [x] the submitted website is focussed on a single, development related issue.
- [x] the `desc` field includes an "actionable sentence" (e.g. "Create something great" or "Transform something into something else").

I created an online CSS selector specificity calculator that quickly lets you find the specificity of selectors and explains them as well.
