### PR TITLE
Added a "skip to content" link (web accessibility improvement)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ static/*.js
 static/*.xml
 static/*.html
 TODO.txt
+
+#WebStorm IDE
+.idea

--- a/site/_includes/base.njk
+++ b/site/_includes/base.njk
@@ -44,11 +44,16 @@
 </head>
 
 <body>
+  <a href="#main-content" class="skip-link padding-xs">Skip to main content</a>
+
   <div class="container">
     {% include 'templates/_logo.njk' %}
     {% include 'templates/_social.njk' %}
     {% include 'templates/_navigation.njk' %}
-    {% include 'templates/_list.njk' %}
+
+    <main id="main-content">
+      {% include 'templates/_list.njk' %}
+    </main>
   </div>
 
   {% set js %}

--- a/site/_includes/css/components/_skip-link.css
+++ b/site/_includes/css/components/_skip-link.css
@@ -1,0 +1,19 @@
+.skip-link {
+  position: absolute;
+  top: -999px;
+  left: -999px;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  background: var(--canvas-bg-color);
+
+  &:active,
+  &:focus,
+  &:hover {
+    left: 1em;
+    top: 1em;
+    width: auto;
+    height: auto;
+    overflow: visible;
+  }
+}

--- a/site/_includes/css/index.css
+++ b/site/_includes/css/index.css
@@ -2,6 +2,7 @@
 @import './components/_buttons.css';
 @import './components/_card.css';
 @import './components/_nav.css';
+@import './components/_skip-link.css';
 @import './util/_colors.css';
 @import './util/_dimensions.css';
 @import './util/_fonts.css';


### PR DESCRIPTION
Added a "hidden until focused" skip link as the first interactive element on the page
Tabbing through the page, it takes over 100 key presses to get to the main content due to the "Tags" links and the GitHub "Avatar" links.
[https://webaim.org/techniques/skipnav/](https://webaim.org/techniques/skipnav/)

Added a `<main>` element to the page as this landmark can be used by assistive technology

![image](https://user-images.githubusercontent.com/4272059/75498048-058ce700-59be-11ea-9e8a-00d0183b33db.png)
