### PR TITLE
Add webhint

### DIFF
--- a/helpers/webhint.json
+++ b/helpers/webhint.json
@@ -1,0 +1,14 @@
+{
+  "name": "webhint",
+  "desc": "Analyze your website to get hints about Accessibility, Compatibility, PWA, Performance, Pitfalls and Security",
+  "url": "https://webhint.io/scanner/",
+  "tags": [
+    "Accessibility",
+    "Performance",
+    "Security"
+  ],
+  "maintainers": [
+    "webhintio"
+  ],
+  "addedAt": "2020-03-04"
+}


### PR DESCRIPTION
Hi, back with another tool that I found very useful!

Sorry for adding 3 tags here, the online scanner does give hints about all of them.

I think a new tag, "Linters" could be a better option here, but at the moment there is only one other helper, JSONLint present among the available helpers.

Edit : Just realized after making the pull that the description could also be changed to "Analyze websites..." instead of "Analyze your website...".