### PR TITLE
Move Color contrast checker from Animation to A11y category

### DIFF
--- a/helpers/color-contrast-checker.json
+++ b/helpers/color-contrast-checker.json
@@ -3,7 +3,7 @@
   "desc": "Quickly check the contrast between colors and get suggestions for better colors",
   "url": "https://polypane.app/color-contrast/",
   "tags": [
-    "Animations",
+    "Accessibility",
     "Color"
   ],
   "maintainers": [


### PR DESCRIPTION
The Color contrast checker is currently in the Animation category.
But it does not seem related to that category and probably should've been added to the Accessibility category instead. So this fixes that.
