### PR TITLE
Fixed broken URL and profile image caused by extra space

### DIFF
--- a/helpers/how-to-target-email-clients.json
+++ b/helpers/how-to-target-email-clients.json
@@ -8,7 +8,7 @@
   ],
   "maintainers": [
     "dylanatsmith",
-    " M-J-Robbins"
+    "M-J-Robbins"
   ],
   "addedAt": "2020-06-30"
 }

--- a/helpers/how-to-target-email-clients.json
+++ b/helpers/how-to-target-email-clients.json
@@ -1,0 +1,14 @@
+{
+  "name": "How to Target Email Clients",
+  "desc": "Single out email clients and platforms using crowdsourced email development techniques",
+  "url": "https://howtotarget.email/",
+  "tags": [
+    "CSS",
+    "Email"
+  ],
+  "maintainers": [
+    "dylanatsmith",
+    " M-J-Robbins"
+  ],
+  "addedAt": "2020-06-30"
+}


### PR DESCRIPTION
Accidentally added an extra space after the comma when adding multiple maintainers:

![image](https://user-images.githubusercontent.com/6905903/86124122-7c540100-bad2-11ea-9d23-021b5947cee4.png)
