### PR TITLE
A better way to wait until the page's fully loaded

### DIFF
--- a/scripts/create-screenshots.js
+++ b/scripts/create-screenshots.js
@@ -32,9 +32,8 @@ async function screenshotHelper(browser, helper, screenshotDir) {
         width: 1000,
         height: 600,
       });
-      await page.goto(helper.url);
-      // sleep to get a proper screenshot of sites showing a spinner
-      await sleep(5000);
+      await page.goto(helper.url, { waitUntil: 'networkidle0' });
+      
       await page.screenshot({ path: doubleSize });
       await page.close();
       sigil = '📸';


### PR DESCRIPTION
I learned recently that you can use the option `waitUntil: 'networkidle0'` to guarantee the page is fully loaded which is better than using a magic number as a sleeping duration 😅
