### PR TITLE
Add pagespeed.compare

### DIFF
--- a/helpers/pagespeed.compare.json
+++ b/helpers/pagespeed.compare.json
@@ -1,0 +1,12 @@
+{
+  "name": "PageSpeed Compare",
+  "desc": "Compare performance metrics of your pages against each other or your competitors using Google PageSpeed Insights.",
+  "url": "https://pagespeed.compare/",
+  "tags": [
+    "Performance"
+  ],
+  "maintainers": [
+    "sanderheilbron"
+  ],
+  "addedAt": "2021-03-30"
+}


### PR DESCRIPTION
Added pagespeed.compare to the list.

Pagespeed Compare is a tool for easy pagespeed benchmarking. The tool makes use of Google PageSpeed Insights API which is powered by Lighthouse and Chrome UX Report, and can be used to compare performance metrics of your pages against each other or your competitors.


