### PR TITLE
add: avatar cropper

### DIFF
--- a/helpers/avatar-cropper.json
+++ b/helpers/avatar-cropper.json
@@ -1,0 +1,12 @@
+{
+  "name": "Avatar Cropper",
+  "desc": "Crop an image from directly its link",
+  "url": "https://avatar.innocenzi.dev",
+  "tags": [
+    "Images"
+  ],
+  "maintainers": [
+    "innocenzi"
+  ],
+  "addedAt": "2021-05-12"
+}


### PR DESCRIPTION
https://avatar.innocenzi.dev

It's a cropping tool I initially made for cropping my online avatars, but I started using it to crop image presentations for my repositories (like [this header](https://github.com/preset/cli/blob/main/README.md)). 

I figured it could belong to `tiny-helpers` but I'd understand if you think it's out of scope. :)

- [x] you only add one (!) new helper per pull request.
- [x] you have checked if an open PR already exists.
- [x] the submitted website is focused on a single, development related issue.
- [x] the `desc` field includes an "actionable sentence" (e.g. "Create something great" or "Transform something into something else").