### PR TITLE
Change url of Tabler Icons

### DIFF
--- a/helpers/tabler-icons.json
+++ b/helpers/tabler-icons.json
@@ -1,10 +1,10 @@
 {
   "name": "Tabler Icons",
-  "desc": "Download fully customizable free SVG icons",
-  "url": "https://tablericons.com/",
+  "desc": "3500+ fully customizable free SVG icons",
+  "url": "https://tabler-icons.io/",
   "tags": [
     "Icons"
   ],
-  "maintainers": [],
+  "maintainers": ["codecalm"],
   "addedAt": "2020-07-13"
 }

--- a/helpers/tabler-icons.json
+++ b/helpers/tabler-icons.json
@@ -1,6 +1,6 @@
 {
   "name": "Tabler Icons",
-  "desc": "3500+ fully customizable free SVG icons",
+  "desc": "Download over 3500 fully customizable free SVG icons",
   "url": "https://tabler-icons.io/",
   "tags": [
     "Icons"


### PR DESCRIPTION
Official website of Tabler Icons is https://tabler-icons.io. tablericons.com is in no way associated with our project

Paweł,
author of Tabler Icons