### PR TITLE
feat: re-add brotli.pro

### DIFF
--- a/helpers/brotli.pro.json
+++ b/helpers/brotli.pro.json
@@ -2,17 +2,7 @@
   "name": "Brotli.Pro",
   "desc": "Check if your website supports Brotli compression",
   "url": "https://www.brotli.pro/",
-  "tags": [
-    "HTML",
-    "HTTP",
-    "Misc",
-    "Network",
-    "Performance",
-    "SEO",
-    "Site analyzers"
-  ],
-  "maintainers": [
-    "manniL"
-  ],
+  "tags": ["Network", "Performance", "Site analyzers"],
+  "maintainers": ["manniL"],
   "addedAt": "2020-01-18"
 }

--- a/helpers/brotli.pro.json
+++ b/helpers/brotli.pro.json
@@ -1,0 +1,18 @@
+{
+  "name": "Brotli.Pro",
+  "desc": "Check if your website supports Brotli compression",
+  "url": "https://www.brotli.pro/",
+  "tags": [
+    "HTML",
+    "HTTP",
+    "Misc",
+    "Network",
+    "Performance",
+    "SEO",
+    "Site analyzers"
+  ],
+  "maintainers": [
+    "manniL"
+  ],
+  "addedAt": "2020-01-18"
+}


### PR DESCRIPTION
This PR re-adds https://www.brotli.pro after it got removed in https://github.com/stefanjudis/tiny-helpers/commit/6f6f27e7b770ca6ace79cb52e586e33637b5ae0a (not sure why 🤔). This PR can be seen as a follow-up of #83 and #97.

- [x] you only add one (!) new helper per pull request.
- [x] you have checked if an open PR already exists.
- [x] the submitted website is focused on a single, development related issue.
- [x] the `desc` field includes an "actionable sentence" (e.g. "Create something great" or "Transform something into something else").
