### PR TITLE
Add sassed

### DIFF
--- a/helpers/sassed.json
+++ b/helpers/sassed.json
@@ -1,0 +1,13 @@
+{
+  "name": "sassed",
+  "desc": "Transform SCSS to CSS",
+  "url": "https://loilo.github.io/sassed/",
+  "tags": [
+    "CSS",
+    "Code"
+  ],
+  "maintainers": [
+    "loilo"
+  ],
+  "addedAt": "2023-06-24"
+}


### PR DESCRIPTION
**tl;dr:** This PR adds the [sassed](https://loilo.github.io/sassed/) SCSS-to-CSS transpiler.

I love tiny transformer tools that are PWA-installable and work offline. [Diffr](https://loilo.github.io/diffr/) has already joined the tiny-helpers repo a couple years back, and in the same vein I just built a tiny Sass editor called [sassed](https://loilo.github.io/sassed/), for those of us who still use Sass and need to quickly transform some code or debug a mixin or the likes.