### PR TITLE
Add PHP Arena

### DIFF
--- a/helpers/php-arena.json
+++ b/helpers/php-arena.json
@@ -1,0 +1,12 @@
+{
+  "name": "PHP Arena",
+  "desc": "Run PHP in your browser",
+  "url": "https://loilo.github.io/php-arena/",
+  "tags": [
+    "Code"
+  ],
+  "maintainers": [
+    "loilo"
+  ],
+  "addedAt": "2023-06-30"
+}


### PR DESCRIPTION
Just like Sass being runnable in pure JavaScript recently allowed to create [sassed](https://loilo.github.io/sassed/), the WordPress team releasing [`@php-wasm/web`](https://npmjs.com/package/@php-wasm/web) allowed to easily run PHP in WebAssembly.

This is the base for [PHP Arena](https://loilo.github.io/php-arena/), a playground PWA which runs PHP code purely in the user's browser.