### PR TITLE
Add video tester helper for debugging codec support

### DIFF
--- a/helpers/videoaudio-tester.json
+++ b/helpers/videoaudio-tester.json
@@ -1,0 +1,12 @@
+{
+  "name": "Video/Audio Tester",
+  "desc": "Debug video codec compatibility issues.",
+  "url": "https://tools.woolyss.com/html5-audio-video-tester/",
+  "tags": [
+    "Videos"
+  ],
+  "maintainers": [
+    "woolyss"
+  ],
+  "addedAt": "2025-09-23"
+}


### PR DESCRIPTION
## Description

Adds an online tool for debugging video + audio codec support issues.

Video + audio codecs make browser support more complicated than just "it supports MP4s". This tool helps you figure out the exact codec incompatibility preventing your video from playing in a browser.

URL: https://tools.woolyss.com/html5-audio-video-tester/

## Criteria

- [X] you only add one (!) new helper per pull request.
- [X] you have checked if an open PR already exists.
- [X] the submitted website is focused on a single, development related issue.
- [X] the `desc` field includes an "actionable sentence" (e.g. "Create something great" or "Transform something into something else").
- [X] the `maintainers` are valid GitHub user names

## Misc

Not open-source. But, I'm mostly sure that GitHub's `woolyss` is the same person.

## Screenshot

Example — An MP4 video that doesn't play because `H.265` (HVEC) is not supported this browser.

<img width="1945" height="1293" alt="Screenshot of the tool trying to play an MP4 video. The video however is not playable, this tool indicates that it's because H.265 or 'HVEC' codec is not supported on my browser." src="https://github.com/user-attachments/assets/058126c4-b46f-4bfb-b564-e78722584d0c" />

