### PR TITLE
Move GeoJSON.io into the Maps category

### DIFF
--- a/helpers/geojson.io.json
+++ b/helpers/geojson.io.json
@@ -3,8 +3,8 @@
   "desc": "Edit map JSON data",
   "url": "http://geojson.io/",
   "tags": [
-    "JSON",
-    "Misc"
+    "Maps",
+    "JSON"
   ],
   "maintainers": [
     "mapbox",


### PR DESCRIPTION
## Description

Moves the [GeoJSON.io](https://tiny-helpers.dev/json/#:~:text=GeoJSON%2Eio,-JSONMisc) tool into the `Maps` category. Replaces `Misc` with `Maps`.

I was about to add GeoJSON.io when I couldn't find it, only to learn that it was not in the Maps category.
