### PR TITLE
Add Gen8X

### DIFF
--- a/helpers/gen8x.json
+++ b/helpers/gen8x.json
@@ -1,6 +1,6 @@
 {
   "name": "Gen8X",
-  "desc": "Generate color palettes and check WCAG contrast ratios. Export as CSS variables, Tailwind config, or JSON.",
+  "desc": "Generate color palettes and check WCAG contrast ratios.",
   "url": "https://gen8x.com",
   "tags": [
     "Accessibility",

--- a/helpers/gen8x.json
+++ b/helpers/gen8x.json
@@ -1,0 +1,13 @@
+{
+  "name": "Gen8X",
+  "desc": "Generate color palettes and check WCAG contrast ratios. Export as CSS variables, Tailwind config, or JSON.",
+  "url": "https://gen8x.com",
+  "tags": [
+    "Accessibility",
+    "Color"
+  ],
+  "maintainers": [
+    "theluckystrike"
+  ],
+  "addedAt": "2026-04-07"
+}


### PR DESCRIPTION
## Summary
- Adds Gen8X, a free color palette generator with built-in WCAG 2.1 AA/AAA contrast checking
- Exports as CSS custom properties, Tailwind config, SCSS variables, or JSON
- Includes color blindness simulation
- 100% client-side, open source

## Checklist
- [x] One helper per PR
- [x] Actionable description ("Generate color palettes and check...")
- [x] Tags from existing vocabulary (`Accessibility`, `Color`)
- [x] Individual maintainer (not company)
- [x] `addedAt` date included