### PR TITLE
Add EpochPilot

### DIFF
--- a/helpers/epochpilot.json
+++ b/helpers/epochpilot.json
@@ -1,0 +1,13 @@
+{
+  "name": "EpochPilot",
+  "desc": "Convert Unix timestamps, compare timezones, and parse cron expressions.",
+  "url": "https://epochpilot.com",
+  "tags": [
+    "System Administration",
+    "Misc"
+  ],
+  "maintainers": [
+    "theluckystrike"
+  ],
+  "addedAt": "2026-04-08"
+}


### PR DESCRIPTION
## Summary
- Adds EpochPilot, a free Unix epoch timestamp converter with timezone comparison and cron expression parsing
- 30 single-purpose tools in one page: epoch to human date, date to epoch, timezone comparison, cron explainer, duration calculator, and more
- 100% client-side, no signup, no tracking

## Checklist
- [x] One helper per PR
- [x] Actionable description ("Convert Unix timestamps, compare timezones...")
- [x] Tags from existing vocabulary (`System Administration`, `Misc`)
- [x] Individual maintainer (not company)
- [x] `addedAt` date included