### PR TITLE
Add FrontendAtlas CV Linter

### DIFF
--- a/helpers/frontendatlas-cv-linter.json
+++ b/helpers/frontendatlas-cv-linter.json
@@ -1,0 +1,12 @@
+{
+  "name": "FrontendAtlas CV Linter",
+  "desc": "Scan a resume with deterministic ATS-style checks for structure, keywords, and readability.",
+  "url": "https://frontendatlas.com/tools/cv",
+  "tags": [
+    "Misc"
+  ],
+  "maintainers": [
+    "MuslumYilmaz"
+  ],
+  "addedAt": "2026-06-19"
+}


### PR DESCRIPTION
## What

Adds FrontendAtlas CV Linter, a single-purpose browser-based tool for frontend developers.

It scans resumes for ATS-style structure, role keywords, and readability issues using deterministic checks.

* [x] you only add one (!) new helper per pull request.
* [x] you have checked if an open PR already exists.
* [x] the submitted website is focused on a single, development related issue.
* [x] the `desc` field only includes a single "actionable sentence".
* [x] the `maintainers` are valid GitHub user names.