### PR TITLE
Add ColorKit Tools

### DIFF
--- a/helpers/colorkit-tools.json
+++ b/helpers/colorkit-tools.json
@@ -1,0 +1,14 @@
+{
+  "name": "ColorKit Tools",
+  "desc": "Generate color palettes, build gradients, convert hex/RGB/HSL, and check WCAG contrast",
+  "url": "https://colorkit.tools/",
+  "tags": [
+    "Color",
+    "Accessibility",
+    "Tool Collections"
+  ],
+  "maintainers": [
+    "hhammoud"
+  ],
+  "addedAt": "2026-06-23"
+}


### PR DESCRIPTION
Adds ColorKit Tools — free, no-signup, in-browser color utilities: palette generator, color picker, gradient maker, hex/RGB/HSL converter, and WCAG contrast checker. Client-side, closed source, maintained by @hhammoud.