### PR TITLE
Add ImgLab Tools

### DIFF
--- a/helpers/imglab-tools.json
+++ b/helpers/imglab-tools.json
@@ -1,0 +1,14 @@
+{
+  "name": "ImgLab Tools",
+  "desc": "Convert, compress, resize images and generate favicons entirely on your device",
+  "url": "https://imglab.tools/",
+  "tags": [
+    "Images",
+    "Favicons",
+    "Tool Collections"
+  ],
+  "maintainers": [
+    "hhammoud"
+  ],
+  "addedAt": "2026-06-23"
+}


### PR DESCRIPTION
Adds ImgLab Tools — free in-browser image utilities that process files locally (nothing uploaded): HEIC/PNG/JPG/WebP converters, compressor, resizer, and favicon generator. Maintained by @hhammoud.