### PR TITLE
Add NetChecks

### DIFF
--- a/helpers/netchecks.json
+++ b/helpers/netchecks.json
@@ -1,0 +1,14 @@
+{
+  "name": "NetChecks",
+  "desc": "Look up IP, DNS, WHOIS, SSL certificates, open ports, and MAC vendors",
+  "url": "https://netchecks.tools/",
+  "tags": [
+    "Network",
+    "System Administration",
+    "Security"
+  ],
+  "maintainers": [
+    "hhammoud"
+  ],
+  "addedAt": "2026-06-23"
+}


### PR DESCRIPTION
Adds NetChecks — free in-browser network diagnostics: IP lookup, DNS records, WHOIS, ping, port checker, SSL certificate inspection, and MAC vendor lookup. Maintained by @hhammoud.