### PR TITLE
Add Subtitle Encoding Converter

### DIFF
--- a/helpers/subtitle-encoding-converter.json
+++ b/helpers/subtitle-encoding-converter.json
@@ -1,0 +1,13 @@
+{
+  "name": "Subtitle Encoding Converter",
+  "desc": "Fix garbled (mojibake) subtitle files by re-decoding legacy encodings to UTF-8.",
+  "url": "https://picute.net/en/tools/subtitle-encoding-converter",
+  "tags": [
+    "Data transformation",
+    "Videos"
+  ],
+  "maintainers": [
+    "cateyelow"
+  ],
+  "addedAt": "2026-06-26"
+}


### PR DESCRIPTION
Adds **Subtitle Encoding Converter** — a free, no-signup tool that fixes garbled (mojibake) subtitle files by re-decoding legacy encodings (Shift-JIS, EUC-KR, GB18030, Big5, Windows-125x) to UTF-8. Everything runs locally in the browser; nothing is uploaded, and it works right away.

Against the criteria:
- One helper in this PR.
- Usable right away, not behind a login, not an API or a JS/CSS library.
- `desc` is an actionable sentence; `tags` reuse existing tags (`Data transformation`, `Videos`); `maintainers` is a human handle.

Disclosure: I'm affiliated with this tool (Picute).
